### PR TITLE
Add methods for irating, ttrating and license class

### DIFF
--- a/ir_webstats_rc/client.py
+++ b/ir_webstats_rc/client.py
@@ -2,6 +2,10 @@ from . import constants as ct
 from .responses.last_races_stats import LastRaceStats
 from .responses.career_stats import CareerStats
 from .responses.yearly_stats import YearlyStats
+from .responses.chart_data.chart_data import ChartData
+from .responses.chart_data.irating import IRating
+from .responses.chart_data.ttrating import TTRating
+from .responses.chart_data.license_class import LicenseClass
 
 import logging
 import requests_async as requests
@@ -362,7 +366,25 @@ class Client:
         url = ct.URL_SESSION_TIMES
         return await self.build_request(url, payload)
 
-    async def stats_chart(self, category, custID, chartType=1):
+    async def get_irating(self, category, custID):
+        chart_type = ct.ChartType.irating
+        response = await self.stats_chart(category, custID, chart_type)
+        irating_list = list(map(lambda x: IRating(x), response.json()))
+        return ChartData(category, ct.ChartType.irating, irating_list)
+
+    async def get_ttrating(self, category, custID):
+        chart_type = ct.ChartType.ttrating
+        response = await self.stats_chart(category, custID, chart_type)
+        ttrating_list = list(map(lambda x: TTRating(x), response.json()))
+        return ChartData(category, chart_type, ttrating_list)
+
+    async def get_license_class(self, category, custID):
+        chart_type = ct.ChartType.license_class
+        response = await self.stats_chart(category, custID, chart_type)
+        license_class_list = list(map(lambda x: LicenseClass(x), response.json()))
+        return ChartData(category, chart_type, license_class_list)
+
+    async def stats_chart(self, category, custID, chartType):
         payload = {
             'custId': custID,
             'catId': category,

--- a/ir_webstats_rc/constants.py
+++ b/ir_webstats_rc/constants.py
@@ -175,6 +175,25 @@ class License:
     pro_class = 6
     pro_wc_class = 7
 
+    @staticmethod
+    def digit_to_string(digit):
+        if digit == 1:
+            return 'Rookie'
+        elif digit == 2:
+            return 'D'
+        elif digit == 3:
+            return 'C'
+        elif digit == 4:
+            return 'B'
+        elif digit == 5:
+            return 'A'
+        elif digit == 6:
+            return 'P'
+        elif digit == 7:
+            return 'P-DWC'
+        else:
+            return None
+
 
 # LOCATIONS (AKA Country Code)
 COUNTRY_CODES = {
@@ -436,6 +455,19 @@ class Category:
     dirt_oval = 3
     dirt_road = 4
 
+    @staticmethod
+    def digit_to_string(digit):
+        if digit == 1:
+            return 'Oval'
+        elif digit == 2:
+            return 'Road'
+        elif digit == 3:
+            return 'Dirt Oval'
+        elif digit == 4:
+            return 'Dirt Road'
+        else:
+            return None
+
 
 class ChartType:
     """Holds the index for the charts available from stats_chart()
@@ -443,6 +475,17 @@ class ChartType:
     irating = 1
     ttrating = 2
     license_class = 3
+
+    @staticmethod
+    def digit_to_string(digit):
+        if digit == 1:
+            return 'iRating'
+        elif digit == 2:
+            return 'TTRating'
+        elif digit == 3:
+            return 'License Class'
+        else:
+            return None
 
 
 class EventType():

--- a/ir_webstats_rc/responses/chart_data/chart_data.py
+++ b/ir_webstats_rc/responses/chart_data/chart_data.py
@@ -1,0 +1,17 @@
+from ...constants import ChartType, Category
+
+
+class ChartData:
+    def __init__(self, category, type, list):
+        self.category = category  # oval, road, dirt_road, dirt_oval
+        self.type = type  # irating, ttrating, or license_class
+        self.list = list  # A list of Iratings, TTRatings, or LicenseClasses
+
+    def current(self):
+        return self.list[-1]
+
+    def type_string(self):
+        return ChartType.digit_to_string(self.type)
+
+    def category_string(self):
+        return Category.digit_to_string(self.category)

--- a/ir_webstats_rc/responses/chart_data/irating.py
+++ b/ir_webstats_rc/responses/chart_data/irating.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+
+
+class IRating:
+    def __init__(self, tuple):
+        self.datetime = self.datetime_from_iracing_timestamp(tuple[0])
+        self.value = tuple[1]
+
+    # iRacing for some reason has an extra 3 0s on the end of the timestamps
+    @staticmethod
+    def datetime_from_iracing_timestamp(timestamp):
+        return datetime.utcfromtimestamp(float(str(timestamp)[:-3]))

--- a/ir_webstats_rc/responses/chart_data/license_class.py
+++ b/ir_webstats_rc/responses/chart_data/license_class.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+from ...constants import License
+
+
+# LicenseClass is in the format `4368` where the first digit represents the license class A through Rookie
+# which can be seen in Constants.License and the next 3 digits are the actual rating, so the example
+# above would be B class with a 3.68 rating
+class LicenseClass:
+    def __init__(self, tuple):
+        self.datetime = self.datetime_from_iracing_timestamp(tuple[0])
+        self.class_number = int(str(tuple[1])[0])
+        self.safety_rating = self.get_safety_rating(str(tuple[1]))
+
+    def class_letter(self):
+        return License.digit_to_string(self.class_number)
+
+    @staticmethod
+    def get_safety_rating(string):
+        relevant_chars = string[1:]
+        return relevant_chars[0] + '.' + relevant_chars[1:]
+
+    # iRacing for some reason has an extra 3 0s on the end of the timestamps
+    @staticmethod
+    def datetime_from_iracing_timestamp(timestamp):
+        return datetime.utcfromtimestamp(float(str(timestamp)[:-3]))

--- a/ir_webstats_rc/responses/chart_data/ttrating.py
+++ b/ir_webstats_rc/responses/chart_data/ttrating.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+
+
+class TTRating:
+    def __init__(self, tuple):
+        self.datetime = self.datetime_from_iracing_timestamp(tuple[0])
+        self.value = tuple[1]
+
+    # iRacing for some reason has an extra 3 0s on the end of the timestamps
+    @staticmethod
+    def datetime_from_iracing_timestamp(timestamp):
+        return datetime.utcfromtimestamp(float(str(timestamp)[:-3]))


### PR DESCRIPTION
Generally people will not want to call `ChartData` because it is unclear
exactly what data it gives you, so these methods get the relevant data
out of the ChartData.

Each of these methods returns a single ChartData object, each of which
contain a list of either iratings, ttratings, or license classes.