### PR TITLE
Fix datetime parsing in chart data

### DIFF
--- a/ir_webstats_rc/client.py
+++ b/ir_webstats_rc/client.py
@@ -409,7 +409,7 @@ class Client:
         lower_bound=0,
         upper_bound=25,
         sort=ct.Sort.start_time,
-        order=ct.Sort.desc,
+        order=ct.Sort.descending,
         format='json',
         category1=1,
         category2=2,

--- a/ir_webstats_rc/responses/chart_data/irating.py
+++ b/ir_webstats_rc/responses/chart_data/irating.py
@@ -6,7 +6,7 @@ class IRating:
         self.datetime = self.datetime_from_iracing_timestamp(tuple[0])
         self.value = tuple[1]
 
-    # iRacing for some reason has an extra 3 0s on the end of the timestamps
+    # iRacing has all of their timestamps in ms so we need to divide
     @staticmethod
     def datetime_from_iracing_timestamp(timestamp):
-        return datetime.utcfromtimestamp(float(str(timestamp)[:-3]))
+        return datetime.utcfromtimestamp(timestamp / 1000)

--- a/ir_webstats_rc/responses/chart_data/license_class.py
+++ b/ir_webstats_rc/responses/chart_data/license_class.py
@@ -19,7 +19,7 @@ class LicenseClass:
         relevant_chars = string[1:]
         return relevant_chars[0] + '.' + relevant_chars[1:]
 
-    # iRacing for some reason has an extra 3 0s on the end of the timestamps
+    # iRacing has all of their timestamps in ms so we need to divide
     @staticmethod
     def datetime_from_iracing_timestamp(timestamp):
-        return datetime.utcfromtimestamp(float(str(timestamp)[:-3]))
+        return datetime.utcfromtimestamp(timestamp / 1000)

--- a/ir_webstats_rc/responses/chart_data/ttrating.py
+++ b/ir_webstats_rc/responses/chart_data/ttrating.py
@@ -6,7 +6,7 @@ class TTRating:
         self.datetime = self.datetime_from_iracing_timestamp(tuple[0])
         self.value = tuple[1]
 
-    # iRacing for some reason has an extra 3 0s on the end of the timestamps
+    # iRacing has all of their timestamps in ms so we need to divide
     @staticmethod
     def datetime_from_iracing_timestamp(timestamp):
-        return datetime.utcfromtimestamp(float(str(timestamp)[:-3]))
+        return datetime.utcfromtimestamp(timestamp / 1000)


### PR DESCRIPTION
Turns out these timestamps are ms instead of s, so we need to divide by
1000. I originally chopped off the last 3 0s because I thought they were
just tacking those on for some reason...

This also fixes what I assume is a typo from our constants that
Sort.desc should be Sort.descending.